### PR TITLE
Add Definject.__using__/1 that replaces Kernel.{def/2, def/1} with Definject.{definject/2, definject/1}

### DIFF
--- a/lib/definject.ex
+++ b/lib/definject.ex
@@ -1,4 +1,12 @@
 defmodule Definject do
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      import Kernel, except: [def: 1, def: 2]
+      import Definject.Def, only: [def: 1, def: 2]
+    end
+  end
+
   @doc """
   `definject` transforms a function to accept a map where dependent functions and modules can be injected.
 

--- a/lib/definject.ex
+++ b/lib/definject.ex
@@ -59,6 +59,17 @@ defmodule Definject do
         })
       end
   """
+  defmacro definject(head, body \\ nil)
+
+  defmacro definject(head, nil) do
+    original =
+      quote do
+        def unquote(head)
+      end
+
+    do_definject(head, [], original, __CALLER__)
+  end
+
   defmacro definject(head, body) do
     original =
       quote do
@@ -66,15 +77,6 @@ defmodule Definject do
       end
 
     do_definject(head, body, original, __CALLER__)
-  end
-
-  defmacro definject(head) do
-    original =
-      quote do
-        def unquote(head)
-      end
-
-    do_definject(head, [], original, __CALLER__)
   end
 
   defp do_definject(head, body, original, %Macro.Env{} = env) do

--- a/lib/definject/def.ex
+++ b/lib/definject/def.ex
@@ -1,0 +1,21 @@
+defmodule Definject.Def do
+  defmacro def(call, expr \\ nil) do
+    if Application.get_env(:definject, :enable, Mix.env() == :test) do
+      case expr do
+        nil ->
+          quote do
+            Definject.definject(unquote(call))
+          end
+
+        expr ->
+          quote do
+            Definject.definject(unquote(call), unquote(expr))
+          end
+      end
+    else
+      quote do
+        Kernel.def(unquote(call), unquote(expr))
+      end
+    end
+  end
+end

--- a/lib/definject/def.ex
+++ b/lib/definject/def.ex
@@ -1,16 +1,8 @@
 defmodule Definject.Def do
   defmacro def(call, expr \\ nil) do
     if Application.get_env(:definject, :enable, Mix.env() == :test) do
-      case expr do
-        nil ->
-          quote do
-            Definject.definject(unquote(call))
-          end
-
-        expr ->
-          quote do
-            Definject.definject(unquote(call), unquote(expr))
-          end
+      quote do
+        Definject.definject(unquote(call), unquote(expr))
       end
     else
       quote do

--- a/test/use_cases/use_test.exs
+++ b/test/use_cases/use_test.exs
@@ -1,0 +1,28 @@
+defmodule Definject.UseTest do
+  use ExUnit.Case, async: true
+  import Definject
+
+  defmodule WithNormalFunction do
+    use Definject
+
+    def add(a, b), do: Calc.sum(a, b)
+  end
+
+  test "with normal function" do
+    assert WithNormalFunction.add(1, 1) == 2
+    assert WithNormalFunction.add(1, 1, mock(%{&Calc.sum/2 => 99})) == 99
+  end
+
+  defmodule WithBodylessClause do
+    use Definject
+
+    def add(a, b \\ 0)
+
+    def add(a, b), do: Calc.sum(a, b)
+  end
+
+  test "with bodyless clause" do
+    assert WithBodylessClause.add(1, 1) == 2
+    assert WithBodylessClause.add(1, 1, mock(%{&Calc.sum/2 => 99})) == 99
+  end
+end


### PR DESCRIPTION
`use Definject` replaces Kernel.{def/2, def/1} with Definject.{definject/2, definject/1}.

```elixir
defmodule Test do
  import Definject

  definject func(a), do: a
end
```

```elixir
defmodule Test do
  use Definject

  def func(a), do: a
end
```